### PR TITLE
Decompile StatusScreenDrawNumber

### DIFF
--- a/include/data/menus/pause_debug.h
+++ b/include/data/menus/pause_debug.h
@@ -23,6 +23,8 @@ extern const u8 sPauseDebugMiscFlags[5];
 
 extern const u8 sStatusScreenSectionSizes[5];
 
+extern const u8 sBlob_58217b_58225c[];
+
 extern const u16 sPauseDebugNumbersIncrementValues[5];
 extern const u16 sPauseDebugNumbersMaxValues[3];
 

--- a/src/data/menus/pause_debug.c
+++ b/src/data/menus/pause_debug.c
@@ -353,4 +353,4 @@ const u8 sDebugSectionInfo[PAUSE_DEBUG_SECTION_END][5] = {
     },
 };
 
-static const u8 sBlob_58217b_58225c[] = INCBIN_U8("data/Blob_58217b_58225c.bin");
+const u8 sBlob_58217b_58225c[] = INCBIN_U8("data/Blob_58217b_58225c.bin");

--- a/src/status_screen.c
+++ b/src/status_screen.c
@@ -9,6 +9,8 @@
 
 #include "structs/samus.h"
 
+#include "data/menus/pause_debug.h"
+
 /**
  * @brief 7e678 | 34 | Handler for the status screen
  * 
@@ -67,7 +69,75 @@ void StatusScreenDrawEverything(void)
  */
 void StatusScreenDrawNumber(u8 section, u16 value, u8 palette, boolu8 isMax)
 {
+    register u16 *dst asm("r9");
+    const u8 *base;
+    const u8 *base2;
+    s32 sec5;
+    s32 yTile;
+    s32 startX;
+    s32 i;
+    s32 width;
+    s32 hasNonZero;
+    s32 tile;
+    s32 divisor;
 
+    base = &sBlob_58217b_58225c[1];
+    sec5 = section * 5;
+
+    yTile = *(sec5 + base) << 5;
+    base2 = base + 2;
+    startX = *(base2 + sec5);
+    dst = (u16 *)0x0600C800 + (yTile + startX);
+    base += 3;
+    width = *(sec5 + base) - startX;
+
+    divisor = sPauseDebugNumbersIncrementValues[width];
+    width++;
+    hasNonZero = 0;
+    i = 0;
+
+    while (divisor > 0)
+    {
+        tile = (value / divisor) % 10;
+        if (tile == 0)
+        {
+            if (hasNonZero == 0)
+            {
+                tile = 0x8c;
+                if (isMax)
+                    tile = 0;
+            }
+            else
+            {
+                tile = 0x80;
+            }
+        }
+        else
+        {
+            hasNonZero = 1;
+            tile += 0x80;
+        }
+
+        if (tile != 0)
+            dst[i] = (palette << 12) | tile;
+        else
+            i--;
+
+        divisor /= 10;
+        i++;
+    }
+
+    if (width != i)
+    {
+        u16 *p;
+        tile = (palette << 12) | 0x8c;
+        p = &dst[i];
+        do {
+            *p = tile;
+            p++;
+            i++;
+        } while (width != i);
+    }
 }
 
 /**


### PR DESCRIPTION
Fills in the `StatusScreenDrawNumber` stub left by #13 in `src/status_screen.c`. Also un-statics `sBlob_58217b_58225c` (renaming the qualifier and adding an `extern` decl) so the new implementation can reference it.

`src/status_screen.c` remains unwired from `linker.ld` — same pattern #13 used, since the remaining four StatusScreen* functions are still stubs. The file will be wired in a follow-up PR once they're all matched.

### Verification

Matching was checked by temporarily wiring `src/status_screen.c` into `linker.ld`, removing the corresponding three `thumb_func_start` blocks from `asm/disasm_0x0807e678.s`, and stripping the four empty stubs from `src/status_screen.c` so the build had no duplicate definitions. With those changes in place:

```
$ make tidy && make -j8 && make check
...
  SHA1SUM mf_us.sha1
mf_us.gba: OK
```

The temporary wiring was reverted before commit; only the genuine source changes are in this PR.